### PR TITLE
add core dir prefix and disable default favorite dir

### DIFF
--- a/favorites.sh
+++ b/favorites.sh
@@ -15,6 +15,9 @@ import configparser
 
 FAVORITES_DEFAULT = "_@Favorites"
 FAVORITES_NAMES = {"fav"}
+CREATE_DEFAULT_FAVORITES = False
+SETUP_ARCADE = False
+COREPREFIX="_All/"
 
 SD_ROOT = "/media/fat"
 STARTUP_SCRIPT = "/media/fat/linux/user-startup.sh"
@@ -1173,6 +1176,8 @@ def add_favorite_workflow():
         # system rom, make mgl file
         rbf, mgl_def = mgl_from_file(file_type, name)
 
+        rbf=COREPREFIX+rbf
+
         if rbf is None or mgl_def is None:
             # this shouldn't really happen due to the contraints on the file picker
             raise Exception("Rom file type does not match any MGL definition")
@@ -1219,8 +1224,10 @@ if __name__ == "__main__":
     if len(sys.argv) == 2 and sys.argv[1] == "refresh":
         refresh_favorites()
     else:
-        create_default_favorites()
-        setup_arcade_files()
+        if CREATE_DEFAULT_FAVORITES:
+            create_default_favorites()
+        if SETUP_ARCADE:
+            setup_arcade_files()
         refresh_favorites()
 
         selection = display_main_menu()


### PR DESCRIPTION
Request for comments. I have my cores in separate dir and only have favorites on the top dir. The arcade disable thing is probably not necessary if that can be fixed to support core prefix as well, but I'd like some guidance how to implement the core prefix anyway.