### PR TITLE
Fix box drawing for PuTTy

### DIFF
--- a/favorites.sh
+++ b/favorites.sh
@@ -211,6 +211,8 @@ GAMES_FOLDERS = (
 WINDOW_TITLE = "Favorites Manager"
 WINDOW_DIMENSIONS = ["20", "75", "20"]
 
+os.environ["NCURSES_NO_UTF8_ACS"]="1"
+
 SELECTION_HISTORY = {
     "__MAIN__": "1",
 }


### PR DESCRIPTION
ncurses box drawing uses VT100 ACS commands by default, but PuTTy ignores them, making dialog(1) boxes a garbled mess.

Fix by instructing ncurses to always use Unicode box drawing characters instead.