### PR TITLE
Add support

### DIFF
--- a/favorites.sh
+++ b/favorites.sh
@@ -155,7 +155,7 @@ MGL_MAP = (
         (({".rom", ".int", ".bin"}, 1, "f", 1),),
     ),
     ("MegaCD", "_Console/MegaCD", (({".cue", ".chd"}, 1, "s", 0),)),
-    ("N64", "_Console/N64", (({".n64", ".z64"}, 1, "f", 1),)),
+    ("N64", "_Console/N64", (({".n64", ".z64", ".v64"}, 1, "f", 1),)),
     ("NeoGeo-CD", "_Console/NeoGeo", (({".cue", ".chd"}, 1, "s", 1),),),
     ("NeoGeo", "_Console/NeoGeo", (({".neo"}, 1, "f", 1),),),
     ("NES", "_Console/NES", (({".nes", ".fds", ".nsf"}, 2, "f", 1),)),

--- a/favorites.sh
+++ b/favorites.sh
@@ -27,6 +27,7 @@ ALLOWED_SD_FILES = {
     "_arcade",
     "_console",
     "_computer",
+    "_dos games",
     "_games",
     "_other",
     "_utility",


### PR DESCRIPTION
I added support for AO486 Files (specifically the 0Mhz DOS collection) by allowing access to the "_Dos Games" folder.

I also added support for N64 *.v64 rom files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `_dos games` folder now displays in the SD card root directory.
  * N64 system now recognizes `.v64` ROM files alongside existing `.n64` and `.z64` formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->